### PR TITLE
feat: impl asref for branded types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,10 @@ uuid = ["dep:uuid"]
 
 [dependencies]
 paste = "1"
-serde = { version = "1", optional = true }
-uuid = { version = "1", optional = true, features = ["v4"] }
+serde = { version = "1", optional = true, default-features = false }
+uuid = { version = "1", optional = true, default-features = false, features = [
+    "v4",
+] }
 sqlx-core = { version = "0.6", optional = true }
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ bty::brand!(
 
 Instances of `UserId` may be constructed using one of the deserialization
 implementations, such as the `serde` one or the `sqlx` one. Manually
-instantiation, though unrecommended, can be done using the `unchecked_from_raw`
+instantiation, though unrecommended, can be done using the `unchecked_from_inner`
 associated function.
 
 See [this thread][tw-ts] from Matt Pocock on Twitter for a more exemplified and
@@ -77,12 +77,12 @@ The problem worsens as the number of uses for the id types grows. For example,
 what about `serde` serialization and deserialization?
 
 `bty` solves this problem by not having separate types for the branded types.
-Instead, a single `Brand` type is used. Defined as `Brand<Tag, Raw>`, it is
+Instead, a single `Brand` type is used. Defined as `Brand<Tag, Inner>`, it is
 generic over a `Tag` type, which discriminates values of different "brands"
-(i.e., domains) and the underlying type, represented by `Raw`.
+(i.e., domains) and the underlying type, represented by `Inner`.
 
-For most Rust's commonly used traits, if `Raw` implements it, then so does
-`Brand`. This means if `Raw` implements `Clone` and `Debug`, `Brand<_, Raw>`
+For most Rust's commonly used traits, if `Inner` implements it, then so does
+`Brand`. This means if `Inner` implements `Clone` and `Debug`, `Brand<_, Inner>`
 will also have them implemented.
 
 Following the previous example, one could use `bty` and have:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,7 @@ macro_rules! brand {
     (
         $(
             $(#[$attr:meta])*
-            $vis:vis type $tag:ident = $raw:ty ;
+            $vis:vis type $tag:ident = $inner:ty ;
         )+
     ) => {
         $crate::paste::paste! {
@@ -54,7 +54,7 @@ macro_rules! brand {
                 }
 
                 $(#[$attr])*
-                $vis type $tag = $crate::Brand<[< Branded $tag Tag >], $raw>;
+                $vis type $tag = $crate::Brand<[< Branded $tag Tag >], $inner>;
             )+
         }
     };
@@ -62,7 +62,7 @@ macro_rules! brand {
 
 /// A generic type to construct branded types.
 ///
-/// This type is generic over the `Tag` and `Raw` types. The `Raw` parameter
+/// This type is generic over the `Tag` and `Inner` types. The `Inner` parameter
 /// corresponds to the underlying type being branded. `Tag` is the type used to
 /// discriminate different branded types, thus having no runtime representation.
 ///
@@ -70,25 +70,19 @@ macro_rules! brand {
 /// more ergonomic since a type for the `Tag` discriminant is automatically
 /// defined.
 ///
-/// If the underlying `Raw` type implements some of Rust's common traits (such
+/// If the underlying `Inner` type implements some of Rust's common traits (such
 /// as `Debug`, `PartialEq`, etc), so does `Brand`.
 #[derive(Clone, Copy)]
-pub struct Brand<Tag, Raw> {
-    raw: Raw,
+pub struct Brand<Tag, Inner> {
+    inner: Inner,
     tag: PhantomData<Tag>,
 }
 
-impl<Tag, Raw> Brand<Tag, Raw> {
+impl<Tag, Inner> Brand<Tag, Inner> {
     /// Returns the underlying branded value.
     #[must_use]
-    pub fn into_raw(self) -> Raw {
-        self.raw
-    }
-
-    /// Returns a reference to the underlying branded value.
-    #[must_use]
-    pub fn as_raw(&self) -> &Raw {
-        &self.raw
+    pub fn into_inner(self) -> Inner {
+        self.inner
     }
 
     /// Constructs a new branded value.
@@ -98,55 +92,67 @@ impl<Tag, Raw> Brand<Tag, Raw> {
     /// Hence, users should be careful when manually constructing branded
     /// values.
     #[must_use]
-    pub fn unchecked_from_raw(raw: Raw) -> Self {
+    pub fn unchecked_from_inner(inner: Inner) -> Self {
         Self {
-            raw,
+            inner,
             tag: PhantomData,
         }
     }
 }
 
-// impl Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash
+// impl Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash, AsRef, AsMut
 
-impl<Tag, Raw> fmt::Debug for Brand<Tag, Raw>
+impl<Tag, Inner> fmt::Debug for Brand<Tag, Inner>
 where
     Tag: crate::Tag,
-    Raw: fmt::Debug,
+    Inner: fmt::Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_tuple(Tag::TAG_NAME).field(&self.raw).finish()
+        f.debug_tuple(Tag::TAG_NAME).field(&self.inner).finish()
     }
 }
 
-impl<Tag, Raw: Default> Default for Brand<Tag, Raw> {
+impl<Tag, Inner: Default> Default for Brand<Tag, Inner> {
     fn default() -> Self {
-        Self::unchecked_from_raw(Raw::default())
+        Self::unchecked_from_inner(Inner::default())
     }
 }
 
-impl<Tag, Raw: PartialEq> PartialEq for Brand<Tag, Raw> {
+impl<Tag, Inner: PartialEq> PartialEq for Brand<Tag, Inner> {
     fn eq(&self, other: &Self) -> bool {
-        self.raw == other.raw
+        self.inner == other.inner
     }
 }
 
-impl<Tag, Raw: Eq> Eq for Brand<Tag, Raw> {}
+impl<Tag, Inner: Eq> Eq for Brand<Tag, Inner> {}
 
-impl<Tag, Raw: PartialOrd> PartialOrd for Brand<Tag, Raw> {
+impl<Tag, Inner: PartialOrd> PartialOrd for Brand<Tag, Inner> {
     fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
-        self.raw.partial_cmp(&other.raw)
+        self.inner.partial_cmp(&other.inner)
     }
 }
 
-impl<Tag, Raw: Ord> Ord for Brand<Tag, Raw> {
+impl<Tag, Inner: Ord> Ord for Brand<Tag, Inner> {
     fn cmp(&self, other: &Self) -> core::cmp::Ordering {
-        self.raw.cmp(&other.raw)
+        self.inner.cmp(&other.inner)
     }
 }
 
-impl<Tag, Raw: hash::Hash> hash::Hash for Brand<Tag, Raw> {
+impl<Tag, Inner: hash::Hash> hash::Hash for Brand<Tag, Inner> {
     fn hash<H: hash::Hasher>(&self, state: &mut H) {
-        self.raw.hash(state);
+        self.inner.hash(state);
+    }
+}
+
+impl<Tag, Inner> AsRef<Inner> for Brand<Tag, Inner> {
+    fn as_ref(&self) -> &Inner {
+        &self.inner
+    }
+}
+
+impl<Tag, Inner> AsMut<Inner> for Brand<Tag, Inner> {
+    fn as_mut(&mut self) -> &mut Inner {
+        &mut self.inner
     }
 }
 
@@ -165,7 +171,7 @@ mod tests {
 
     #[test]
     fn test_debug() {
-        let id = TestId::unchecked_from_raw(10);
+        let id = TestId::unchecked_from_inner(10);
         let s = format!("{id:?}");
         assert_eq!(s, "TestId(10)");
     }

--- a/src/misc.rs
+++ b/src/misc.rs
@@ -3,6 +3,6 @@ impl<Tag> crate::Brand<Tag, uuid::Uuid> {
     /// Creates a new brand value using the `new_v4`'s [`uuid::Uuid`] function.
     #[must_use]
     pub fn new_v4() -> Self {
-        Self::unchecked_from_raw(uuid::Uuid::new_v4())
+        Self::unchecked_from_inner(uuid::Uuid::new_v4())
     }
 }

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -2,27 +2,27 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::Brand;
 
-impl<B, Raw> Serialize for Brand<B, Raw>
+impl<B, Inner> Serialize for Brand<B, Inner>
 where
-    Raw: Serialize,
+    Inner: Serialize,
 {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
-        self.raw.serialize(serializer)
+        self.inner.serialize(serializer)
     }
 }
 
-impl<'de, B, Raw> Deserialize<'de> for Brand<B, Raw>
+impl<'de, B, Inner> Deserialize<'de> for Brand<B, Inner>
 where
-    Raw: for<'a> Deserialize<'a>,
+    Inner: for<'a> Deserialize<'a>,
 {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
     {
-        Raw::deserialize(deserializer).map(Self::unchecked_from_raw)
+        Inner::deserialize(deserializer).map(Self::unchecked_from_inner)
     }
 }
 
@@ -43,7 +43,7 @@ mod tests {
     #[test]
     fn test_serialize_deserialize() {
         let t = Test {
-            id: TestId::unchecked_from_raw(123),
+            id: TestId::unchecked_from_inner(123),
             other: "olá".into(),
         };
 

--- a/src/sqlx.rs
+++ b/src/sqlx.rs
@@ -9,33 +9,33 @@ use crate::Brand;
 
 type BoxError = Box<dyn core::error::Error + Send + Sync + 'static>;
 
-impl<Db, Tag, Raw> Type<Db> for Brand<Tag, Raw>
+impl<Db, Tag, Inner> Type<Db> for Brand<Tag, Inner>
 where
     Db: Database,
-    Raw: Type<Db>,
+    Inner: Type<Db>,
 {
     fn type_info() -> Db::TypeInfo {
-        Raw::type_info()
+        Inner::type_info()
     }
 }
 
-impl<'de, Db, Tag, Raw> Decode<'de, Db> for Brand<Tag, Raw>
+impl<'de, Db, Tag, Inner> Decode<'de, Db> for Brand<Tag, Inner>
 where
     Db: Database,
-    Raw: for<'a> Decode<'a, Db>,
+    Inner: for<'a> Decode<'a, Db>,
 {
-    fn decode(value: <Db as HasValueRef<'de>>::ValueRef) -> Result<Brand<Tag, Raw>, BoxError> {
-        let raw = <Raw as Decode<Db>>::decode(value)?;
-        Ok(Brand::unchecked_from_raw(raw))
+    fn decode(value: <Db as HasValueRef<'de>>::ValueRef) -> Result<Brand<Tag, Inner>, BoxError> {
+        let inner = <Inner as Decode<Db>>::decode(value)?;
+        Ok(Brand::unchecked_from_inner(inner))
     }
 }
 
-impl<'en, Db, Tag, Raw> Encode<'en, Db> for Brand<Tag, Raw>
+impl<'en, Db, Tag, Inner> Encode<'en, Db> for Brand<Tag, Inner>
 where
     Db: Database,
-    Raw: for<'a> Encode<'a, Db>,
+    Inner: for<'a> Encode<'a, Db>,
 {
     fn encode_by_ref(&self, buf: &mut <Db as HasArguments<'en>>::ArgumentBuffer) -> IsNull {
-        self.raw.encode_by_ref(buf)
+        self.inner.encode_by_ref(buf)
     }
 }


### PR DESCRIPTION
This PR does a couple of things, starting with the rename from `Raw` to `Inner`,
implements `AsRef<Inner>` for branded types, and also adds a new `as_mut`
function to avoid the need to extract the value and create it again every time.